### PR TITLE
Update VerifyCodeview

### DIFF
--- a/verifycode/src/main/java/com/github/irvingryan/VerifyCodeView.java
+++ b/verifycode/src/main/java/com/github/irvingryan/VerifyCodeView.java
@@ -252,9 +252,9 @@ public class VerifyCodeView extends View {
     public void setText(String code){
         if (code==null)
             throw new NullPointerException("Code must not null!");
-        if (code.length()>4){
-            throw new IllegalArgumentException("Code must less than 4 letters!");
-        }
+//         if (code.length()>4){
+//             throw new IllegalArgumentException("Code must less than 4 letters!");
+//         }
         codeBuilder=new StringBuilder();
         codeBuilder.append(code);
         invalidate();


### PR DESCRIPTION
there is an issue when setText() is called and more than 4 characters are parsed to it, a `"Code must less than 4 letters!"` error is thrown at line 255 to 256. For instance, i receive verification SMS and called setText("123456")  programmatically, an error will be thrown